### PR TITLE
Set the correct image available callback to nil

### DIFF
--- a/framework/Source/iOS/PictureOutput.swift
+++ b/framework/Source/iOS/PictureOutput.swift
@@ -64,7 +64,7 @@ public class PictureOutput: ImageConsumer {
             imageCallback(image)
             
             if onlyCaptureNextFrame {
-                encodedImageAvailableCallback = nil
+                imageAvailableCallback = nil
             }
         }
         


### PR DESCRIPTION
If onlyCaptureNextFrame is true, the imageAvailableCallback should be set to nil