### PR TITLE
Change `uniformSettings` from `internal` to `public`

### DIFF
--- a/framework/Source/BasicOperation.swift
+++ b/framework/Source/BasicOperation.swift
@@ -34,6 +34,7 @@ public class BasicOperation: ImageProcessingOperation {
         }
     }
     public var activatePassthroughOnNextFrame:Bool = false
+    public var uniformSettings = ShaderUniformSettings()
 
     // MARK: -
     // MARK: Internal
@@ -44,7 +45,6 @@ public class BasicOperation: ImageProcessingOperation {
     var inputFramebuffers = [UInt:Framebuffer]()
     var renderFramebuffer:Framebuffer!
     var outputFramebuffer:Framebuffer { get { return renderFramebuffer } }
-    var uniformSettings = ShaderUniformSettings()
     let usesAspectRatio:Bool
     let maskImageRelay = ImageRelay()
     var maskFramebuffer:Framebuffer?

--- a/framework/Source/ShaderUniformSettings.swift
+++ b/framework/Source/ShaderUniformSettings.swift
@@ -15,37 +15,37 @@
 public struct ShaderUniformSettings {
     private var uniformValues = [String:Any]()
 
-    subscript(index:String) -> Float? {
+    public subscript(index:String) -> Float? {
         get { return uniformValues[index] as? Float}
         set(newValue) { uniformValues[index] = newValue }
     }
     
-    subscript(index:String) -> Int? {
+    public subscript(index:String) -> Int? {
         get { return uniformValues[index] as? Int }
         set(newValue) { uniformValues[index] = newValue }
     }
 
-    subscript(index:String) -> Color? {
+    public subscript(index:String) -> Color? {
         get { return uniformValues[index] as? Color }
         set(newValue) { uniformValues[index] = newValue }
     }
 
-    subscript(index:String) -> Position? {
+    public subscript(index:String) -> Position? {
         get { return uniformValues[index] as? Position }
         set(newValue) { uniformValues[index] = newValue }
     }
 
-    subscript(index:String) -> Size? {
+    public subscript(index:String) -> Size? {
         get { return uniformValues[index] as? Size}
         set(newValue) { uniformValues[index] = newValue }
     }
 
-    subscript(index:String) -> Matrix4x4? {
+    public subscript(index:String) -> Matrix4x4? {
         get { return uniformValues[index] as? Matrix4x4 }
         set(newValue) { uniformValues[index] = newValue }
     }
 
-    subscript(index:String) -> Matrix3x3? {
+    public subscript(index:String) -> Matrix3x3? {
         get { return uniformValues[index] as? Matrix3x3}
         set(newValue) { uniformValues[index] = newValue }
     }


### PR DESCRIPTION
Hi,

I was trying to make a custom filter operation, with an implementation similar to this:
https://github.com/BradLarson/GPUImage2/blob/master/framework/Source/Operations/ContrastAdjustment.swift

I needed `uniformSettings` to be `public` in order to do similar to this outside of the GPUImage module:
```swift
public var contrast:Float = 1.0 { didSet { uniformSettings["contrast"] = contrast } }
```

This PR changes some fields to public to make that possible.

-----

I'm also interested in doing something like `GPUImageToneCurveFilter`. I suspect that this hasn't been done yet because it's non-trivial, is that the case?