### PR TITLE
On iOS Simulator, try Camera() fails to throw CameraError but crashes in deinit()

### DIFF
--- a/framework/GPUImage-iOS.xcodeproj/project.pbxproj
+++ b/framework/GPUImage-iOS.xcodeproj/project.pbxproj
@@ -41,8 +41,6 @@
 		BCC49FB81CD6E3D900B63EEB /* MovieInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC49FB71CD6E3D900B63EEB /* MovieInput.swift */; };
 		BCD03F0F1CA23D6300271751 /* Camera.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD03F0E1CA23D6300271751 /* Camera.swift */; };
 		BCD1B1301C66A262001F2BDC /* GPUImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCD1B1251C66A262001F2BDC /* GPUImage.framework */; };
-		BCD1B1351C66A262001F2BDC /* GPUImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD1B1341C66A262001F2BDC /* GPUImageTests.swift */; };
-		BCD1B1431C66A695001F2BDC /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BCD1B1411C66A68E001F2BDC /* Info.plist */; };
 		BCD985D21CA48CC2001FF01F /* PictureInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD985D11CA48CC2001FF01F /* PictureInput.swift */; };
 		BCE316EB1CA0E5CC00323D5B /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCE316EA1CA0E5CC00323D5B /* OpenGLES.framework */; };
 		BCE316FA1CA0E69800323D5B /* Framebuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE316F31CA0E69800323D5B /* Framebuffer.swift */; };
@@ -168,6 +166,7 @@
 		BCFB074C1CBF2BC1009B2333 /* ZoomBlur.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFB073E1CBF2BC1009B2333 /* ZoomBlur.swift */; };
 		BCFB07991CBF4B44009B2333 /* TextureInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFB07981CBF4B44009B2333 /* TextureInput.swift */; };
 		BCFB079C1CBF4B92009B2333 /* TextureOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFB079B1CBF4B92009B2333 /* TextureOutput.swift */; };
+		F449DE351D5C0CB900BCBC64 /* GPUImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F449DE341D5C0CB900BCBC64 /* GPUImageTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -227,7 +226,6 @@
 		BCD03F0E1CA23D6300271751 /* Camera.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Camera.swift; path = Source/iOS/Camera.swift; sourceTree = "<group>"; };
 		BCD1B1251C66A262001F2BDC /* GPUImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GPUImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCD1B12F1C66A262001F2BDC /* GPUImageTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GPUImageTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		BCD1B1341C66A262001F2BDC /* GPUImageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GPUImageTests.swift; path = Tests/iOS/GPUImageTests.swift; sourceTree = "<group>"; };
 		BCD1B13F1C66A676001F2BDC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Source/iOS/Info.plist; sourceTree = SOURCE_ROOT; };
 		BCD1B1411C66A68E001F2BDC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Tests/iOS/Info.plist; sourceTree = SOURCE_ROOT; };
 		BCD985D11CA48CC2001FF01F /* PictureInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PictureInput.swift; path = Source/iOS/PictureInput.swift; sourceTree = "<group>"; };
@@ -479,6 +477,7 @@
 		BCFB079B1CBF4B92009B2333 /* TextureOutput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TextureOutput.swift; path = Source/TextureOutput.swift; sourceTree = "<group>"; };
 		BCFB079D1CBF4E39009B2333 /* FiveInput.vsh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.glsl; name = FiveInput.vsh; path = Source/Operations/Shaders/FiveInput.vsh; sourceTree = "<group>"; };
 		BCFB079E1CBF4E39009B2333 /* FourInput.vsh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.glsl; name = FourInput.vsh; path = Source/Operations/Shaders/FourInput.vsh; sourceTree = "<group>"; };
+		F449DE341D5C0CB900BCBC64 /* GPUImageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GPUImageTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -539,10 +538,10 @@
 			isa = PBXGroup;
 			children = (
 				BCD1B1411C66A68E001F2BDC /* Info.plist */,
-				BCD1B1341C66A262001F2BDC /* GPUImageTests.swift */,
+				F449DE341D5C0CB900BCBC64 /* GPUImageTests.swift */,
 			);
 			name = Tests;
-			path = GPUImageTests;
+			path = Tests/iOS;
 			sourceTree = "<group>";
 		};
 		BCE316E81CA0E59B00323D5B /* Base */ = {
@@ -1007,7 +1006,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BCD1B1431C66A695001F2BDC /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1176,7 +1174,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BCD1B1351C66A262001F2BDC /* GPUImageTests.swift in Sources */,
+				F449DE351D5C0CB900BCBC64 /* GPUImageTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1326,7 +1324,7 @@
 		BCD1B13D1C66A262001F2BDC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				INFOPLIST_FILE = GPUImageTests/Info.plist;
+				INFOPLIST_FILE = Tests/iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.sunsetlakesoftware.GPUImageTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1336,7 +1334,7 @@
 		BCD1B13E1C66A262001F2BDC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				INFOPLIST_FILE = GPUImageTests/Info.plist;
+				INFOPLIST_FILE = Tests/iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.sunsetlakesoftware.GPUImageTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/framework/Source/iOS/Camera.swift
+++ b/framework/Source/iOS/Camera.swift
@@ -94,6 +94,9 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
         self.captureSession = AVCaptureSession()
         self.captureSession.beginConfiguration()
 
+        // Add the video frame output
+        videoOutput = AVCaptureVideoDataOutput()
+        videoOutput.alwaysDiscardsLateVideoFrames = false
         if let cameraDevice = cameraDevice {
             self.inputCamera = cameraDevice
         } else {
@@ -101,7 +104,6 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
                 self.inputCamera = device
             } else {
                 self.videoInput = nil
-                self.videoOutput = nil
                 self.yuvConversionShader = nil
                 self.inputCamera = nil
                 super.init()
@@ -113,7 +115,6 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
             self.videoInput = try AVCaptureDeviceInput(device:inputCamera)
         } catch {
             self.videoInput = nil
-            self.videoOutput = nil
             self.yuvConversionShader = nil
             super.init()
             throw error
@@ -122,9 +123,6 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
             captureSession.addInput(videoInput)
         }
         
-        // Add the video frame output
-        videoOutput = AVCaptureVideoDataOutput()
-        videoOutput.alwaysDiscardsLateVideoFrames = false
 
         if captureAsYUV {
             supportsFullYUVRange = false

--- a/framework/Tests/iOS/GPUImageTests.swift
+++ b/framework/Tests/iOS/GPUImageTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 @testable import GPUImage
+import AVFoundation
 
 class GPUImageTests: XCTestCase {
     
@@ -30,6 +31,19 @@ class GPUImageTests: XCTestCase {
         // This is an example of a performance test case.
         self.measureBlock {
             // Put the code you want to measure the time of here.
+        }
+    }
+    
+    func testCameraError() {
+        if ( PhysicalCameraLocation.BackFacing.device() == nil && PhysicalCameraLocation.FrontFacing.device() == nil) {
+            do {
+                let camera = try Camera(sessionPreset:AVCaptureSessionPreset640x480)
+                XCTFail("Camera():\(camera) should throw error on Simulator")
+            } catch {
+                XCTAssert(error is CameraError, "Exception should be CameraError")
+            }
+        } else {
+            XCTAssert(true, "Untestable condition: camera available")
         }
     }
     


### PR DESCRIPTION
`videoOutput!` member of Camera class set to nil before  throwing `CameraError` and that causes `Camera.deinit() `crash with 

> fatal error: unexpectedly found nil while unwrapping an Optional value

 while attempting to access `videoOutput!`

To solve the issue, these changes:
1. Fix iOS GPUImageTests build failure by correcting file locations in xcodeproj
2. Add testCameraError() test case to harness the code reproduces the crash
3. Fix the crash by assigning videoOutput! with a valid object, not nil