### PR TITLE
open access modifier for BasicOperations

### DIFF
--- a/framework/Source/BasicOperation.swift
+++ b/framework/Source/BasicOperation.swift
@@ -11,7 +11,7 @@ public func defaultVertexShaderForInputs(_ inputCount:UInt) -> String {
     }
 }
 
-public class BasicOperation: ImageProcessingOperation {
+open class BasicOperation: ImageProcessingOperation {
     public let maximumInputs:UInt
     public var overriddenOutputSize:Size?
     public var overriddenOutputRotation:Rotation?

--- a/framework/Source/OperationGroup.swift
+++ b/framework/Source/OperationGroup.swift
@@ -1,4 +1,4 @@
-public class OperationGroup: ImageProcessingOperation {
+open class OperationGroup: ImageProcessingOperation {
     let inputImageRelay = ImageRelay()
     let outputImageRelay = ImageRelay()
     

--- a/framework/Source/TextureSamplingOperation.swift
+++ b/framework/Source/TextureSamplingOperation.swift
@@ -1,4 +1,4 @@
-public class TextureSamplingOperation: BasicOperation {
+open class TextureSamplingOperation: BasicOperation {
     public var overriddenTexelSize:Size?
     
     public init(vertexShader:String = NearbyTexelSamplingVertexShader, fragmentShader:String, numberOfInputs:UInt = 1) {

--- a/framework/Source/TwoStageOperation.swift
+++ b/framework/Source/TwoStageOperation.swift
@@ -1,4 +1,4 @@
-public class TwoStageOperation: BasicOperation {
+open class TwoStageOperation: BasicOperation {
     public var overrideDownsamplingOptimization:Bool = false
 
 //    override var outputFramebuffer:Framebuffer { get { return Framebuffer } }


### PR DESCRIPTION
In order for library users to subclass these basic operations outside the module in Swift 3, the access modifiers need to change to open. 
I didn't check if there were any more relevant classes to make open. 

https://github.com/apple/swift-evolution/blob/master/proposals/0117-non-public-subclassable-by-default.md

> This proposal suggests distinguishing these concepts. It creates a new access level open beyond public; for now, open can only be used on classes and overridable class members. A public class will only be usable by other modules, but not subclassable. An open class will be both usable and subclass able.