### PR TITLE
Support portrait of a front camera in iOS

### DIFF
--- a/framework/GPUImage-iOS.xcodeproj/project.pbxproj
+++ b/framework/GPUImage-iOS.xcodeproj/project.pbxproj
@@ -965,7 +965,6 @@
 				TargetAttributes = {
 					BCD1B1241C66A262001F2BDC = {
 						CreatedOnToolsVersion = 7.2;
-						DevelopmentTeam = J2U2U9GBML;
 						LastSwiftMigration = 0800;
 					};
 					BCD1B12E1C66A262001F2BDC = {
@@ -1292,6 +1291,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1314,6 +1314,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/framework/Source/iOS/Camera.swift
+++ b/framework/Source/iOS/Camera.swift
@@ -11,8 +11,8 @@ public enum PhysicalCameraLocation {
     // Documentation: "The front-facing camera would always deliver buffers in AVCaptureVideoOrientationLandscapeLeft and the back-facing camera would always deliver buffers in AVCaptureVideoOrientationLandscapeRight."
     func imageOrientation() -> ImageOrientation {
         switch self {
-            case .backFacing: return .landscapeRight
-            case .frontFacing: return .landscapeLeft
+            case .backFacing: return .portrait
+            case .frontFacing: return .portrait
         }
     }
     
@@ -151,6 +151,19 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
             captureSession.addOutput(videoOutput)
         }
         captureSession.sessionPreset = sessionPreset
+        
+        var captureConnection: AVCaptureConnection!
+        for connection in videoOutput.connections {
+            for port in (connection as AnyObject).inputPorts {
+                if (port as AnyObject).mediaType == AVMediaTypeVideo {
+                    captureConnection = connection as? AVCaptureConnection
+                }
+            }
+        }
+        if captureConnection.isVideoOrientationSupported {
+            captureConnection.videoOrientation = .portrait
+        }
+        
         captureSession.commitConfiguration()
 
         super.init()


### PR DESCRIPTION
When using a front camera, the image is upside down. I conquer this with changing AVCaptureConnection.

In this state:
- Back camera: Vertically good, Horizontally good.
- Front camera: Vertically good, Horizontally inverted.

How do you think?

If this changes doesn't fit your taste, please close at ease :)
