### PR TITLE
added NSCameraUsageDescription to ios examples plist

### DIFF
--- a/examples/iOS/FilterShowcase/FilterShowcaseSwift/Info.plist
+++ b/examples/iOS/FilterShowcase/FilterShowcaseSwift/Info.plist
@@ -48,5 +48,7 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>App needs this permision to work</string>
 </dict>
 </plist>

--- a/examples/iOS/SimpleVideoFilter/SimpleVideoFilter/Info.plist
+++ b/examples/iOS/SimpleVideoFilter/SimpleVideoFilter/Info.plist
@@ -43,5 +43,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>App needs this permision to work</string>
 </dict>
 </plist>


### PR DESCRIPTION
This option must be added to iOS examples info.plists otherwise they won’t work on device