### PR TITLE
Fix framebuffer overrelease error due to async target counts for iOS

### DIFF
--- a/framework/Source/Pipeline.swift
+++ b/framework/Source/Pipeline.swift
@@ -92,7 +92,7 @@ class WeakImageConsumer {
 
 public class TargetContainer:Sequence {
     var targets = [WeakImageConsumer]()
-    var count:Int { get {return targets.count}}
+    var count:Int { get { return self.dispatchQueue.sync{return targets.count}}}
 #if !os(Linux)
     let dispatchQueue = DispatchQueue(label:"com.sunsetlakesoftware.GPUImage.targetContainerQueue", attributes: [])
 #endif


### PR DESCRIPTION
The frame buffers would not get updated due to the target counts being off from previous append calls.  This can be reproduced by synchronous calls to processImage.