### PR TITLE
Image buffer size

### DIFF
--- a/framework/Source/Operations/ImageBuffer.swift
+++ b/framework/Source/Operations/ImageBuffer.swift
@@ -10,7 +10,7 @@ public class ImageBuffer: ImageProcessingOperation {
 
     public func newFramebufferAvailable(_ framebuffer:Framebuffer, fromSourceIndex:UInt) {
         bufferedFramebuffers.append(framebuffer)
-        if (bufferedFramebuffers.count > Int(bufferSize)) {
+        if (bufferedFramebuffers.count >= Int(bufferSize)) {
             let releasedFramebuffer = bufferedFramebuffers.removeFirst()
             updateTargetsWithFramebuffer(releasedFramebuffer)
             releasedFramebuffer.unlock()

--- a/framework/Source/Pipeline.swift
+++ b/framework/Source/Pipeline.swift
@@ -92,7 +92,7 @@ class WeakImageConsumer {
 
 public class TargetContainer:Sequence {
     var targets = [WeakImageConsumer]()
-    var count:Int { get {return targets.count}}
+    var count:Int { get { return self.dispatchQueue.sync{return targets.count}}}
 #if !os(Linux)
     let dispatchQueue = DispatchQueue(label:"com.sunsetlakesoftware.GPUImage.targetContainerQueue", attributes: [])
 #endif


### PR DESCRIPTION
The ImageBuffer class was adding one too many buffers via the comparison operator.

Symptoms:
This became apparent when using a 2 frame max filter as the image would flicker.  

The low pass filter appears to work better now with this change.  

My previous fix for the sync error is in here too...sorry, I will back it out if requested.  Bad branching strategy on my part :)