### PR TITLE
Make the AVCaptureSession public

### DIFF
--- a/framework/Source/iOS/Camera.swift
+++ b/framework/Source/iOS/Camera.swift
@@ -65,7 +65,7 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
     
     public let targets = TargetContainer()
     public var delegate: CameraDelegate?
-    let captureSession:AVCaptureSession
+    public let captureSession:AVCaptureSession
     let inputCamera:AVCaptureDevice!
     let videoInput:AVCaptureDeviceInput!
     let videoOutput:AVCaptureVideoDataOutput!


### PR DESCRIPTION
Thanks for your work on GPUImage2!

I have a use-case where I need access to the underlying capture session to make it work more smoothly with CoreImage. Perhaps there are some good reasons for keeping it `internal`.  I just wanted to submit this pull request to start a discussion about whether or not allowing the `captureSession` on `Camera` to be `public` might be useful for others as well.