### PR TITLE
Fix EAGLContext drawableProperties dictionary in RenderView

### DIFF
--- a/framework/Source/iOS/RenderView.swift
+++ b/framework/Source/iOS/RenderView.swift
@@ -41,7 +41,7 @@ public class RenderView:UIView, ImageConsumer {
         
         let eaglLayer = self.layer as! CAEAGLLayer
         eaglLayer.isOpaque = true
-        eaglLayer.drawableProperties = [NSNumber(value:false): kEAGLDrawablePropertyRetainedBacking, kEAGLColorFormatRGBA8: kEAGLDrawablePropertyColorFormat]
+        eaglLayer.drawableProperties = [kEAGLDrawablePropertyRetainedBacking: NSNumber(value:false), kEAGLDrawablePropertyColorFormat: kEAGLColorFormatRGBA8]
     }
     
     deinit {


### PR DESCRIPTION
Functionally this doesn't affect anything since the default values are being used but I noticed an old Objective-C style dictionary literal being created with values followed by keys. Could save someone some confusion down the line :)