### PR TITLE
Add premultipliedLast BitmapInfo to allow transparent background

### DIFF
--- a/framework/Source/Mac/PictureOutput.swift
+++ b/framework/Source/Mac/PictureOutput.swift
@@ -61,7 +61,7 @@ public class PictureOutput: ImageConsumer {
         guard let dataProvider = CGDataProvider(dataInfo: nil, data: data, size: imageByteSize, releaseData: dataProviderReleaseCallback) else {fatalError("Could not create CGDataProvider")}
         let defaultRGBColorSpace = CGColorSpaceCreateDeviceRGB()
         
-        return CGImage(width: Int(framebuffer.size.width), height: Int(framebuffer.size.height), bitsPerComponent:8, bitsPerPixel:32, bytesPerRow:4 * Int(framebuffer.size.width), space:defaultRGBColorSpace, bitmapInfo:CGBitmapInfo() /*| CGImageAlphaInfo.Last*/, provider:dataProvider, decode:nil, shouldInterpolate:false, intent:.defaultIntent)!
+      return CGImage(width: Int(framebuffer.size.width), height: Int(framebuffer.size.height), bitsPerComponent:8, bitsPerPixel:32, bytesPerRow:4 * Int(framebuffer.size.width), space:defaultRGBColorSpace, bitmapInfo:CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue), provider:dataProvider, decode:nil, shouldInterpolate:false, intent:.defaultIntent)!
     }
     
     public func newFramebufferAvailable(_ framebuffer:Framebuffer, fromSourceIndex:UInt) {


### PR DESCRIPTION
When creating a CGImage in cgImageFromFramebuffer method in PictureOutput class, the CGBitmapInfo was empty. Creating a CGBitmaInfo with a GCImageAlphaInfo.premultipliedLast rawValue it will take care of the alpha channel.
Any drawbacks about this?