### PR TITLE
Fix MovieOutput crash when recording isn't started immediately

### DIFF
--- a/framework/Source/iOS/MovieOutput.swift
+++ b/framework/Source/iOS/MovieOutput.swift
@@ -188,7 +188,7 @@ public class MovieOutput: ImageConsumer, AudioEncodingTarget {
     }
     
     public func processAudioBuffer(_ sampleBuffer:CMSampleBuffer) {
-        guard let assetWriterAudioInput = assetWriterAudioInput else { return }
+        guard isRecording, let assetWriterAudioInput = assetWriterAudioInput else { return }
         
         sharedImageProcessingContext.runOperationSynchronously{
             let currentSampleTime = CMSampleBufferGetOutputPresentationTimeStamp(sampleBuffer)


### PR DESCRIPTION
Fixes "Cannot call method when status is 1" on call to startRecording()
that happens if recording isn't started immediately after attaching the
input. This fix makes it possible to attach the MovieOutput to the
camera up front and then call startRecording later on without any visual
hiccups.