### PR TITLE
Changed Framebuffer Caching to work under ARC by using Framebuffer.Core class and removed unnecessary methods and properties

### DIFF
--- a/framework/Source/BasicOperation.swift
+++ b/framework/Source/BasicOperation.swift
@@ -21,13 +21,12 @@ open class BasicOperation: ImageProcessingOperation {
         didSet {
             if let mask = mask {
                 maskImageRelay.newImageCallback = {[weak self] framebuffer in
-                    self?.maskFramebuffer?.unlock()
-                    framebuffer.lock()
+                    
                     self?.maskFramebuffer = framebuffer
                 }
                 mask.addTarget(maskImageRelay)
             } else {
-                maskFramebuffer?.unlock()
+                
                 maskImageRelay.removeSourceAtIndex(0)
                 maskFramebuffer = nil
             }
@@ -85,9 +84,6 @@ open class BasicOperation: ImageProcessingOperation {
     // MARK: Rendering
     
     public func newFramebufferAvailable(_ framebuffer:Framebuffer, fromSourceIndex:UInt) {
-        if let previousFramebuffer = inputFramebuffers[fromSourceIndex] {
-            previousFramebuffer.unlock()
-        }
         inputFramebuffers[fromSourceIndex] = framebuffer
 
         guard (!activatePassthroughOnNextFrame) else { // Use this to allow a bootstrap of cyclical processing, like with a low pass filter
@@ -143,7 +139,7 @@ open class BasicOperation: ImageProcessingOperation {
                     renderFramebuffer.timingStyle = .videoFrame(timestamp:timestamp)
                 }
                 
-                framebuffer.unlock()
+                
             } else {
                 remainingFramebuffers[key] = framebuffer
             }
@@ -186,7 +182,7 @@ open class BasicOperation: ImageProcessingOperation {
         sharedImageProcessingContext.runOperationAsynchronously{
             guard let renderFramebuffer = self.renderFramebuffer, (!renderFramebuffer.timingStyle.isTransient()) else { return }
             
-            renderFramebuffer.lock()
+            
             target.newFramebufferAvailable(renderFramebuffer, fromSourceIndex:atIndex)
         }
     }

--- a/framework/Source/CameraConversion.swift
+++ b/framework/Source/CameraConversion.swift
@@ -33,7 +33,5 @@ public func convertYUVToRGB(shader:ShaderProgram, luminanceFramebuffer:Framebuff
     var uniformSettings = ShaderUniformSettings()
     uniformSettings["colorConversionMatrix"] = colorConversionMatrix
     renderQuadWithShader(shader, uniformSettings:uniformSettings, vertexBufferObject:sharedImageProcessingContext.standardImageVBO, inputTextures:textureProperties)
-    luminanceFramebuffer.unlock()
-    chrominanceFramebuffer.unlock()
-    secondChrominanceFramebuffer?.unlock()
+    
 }

--- a/framework/Source/ImageGenerator.swift
+++ b/framework/Source/ImageGenerator.swift
@@ -14,7 +14,6 @@ public class ImageGenerator: ImageSource {
     }
     
     public func transmitPreviousImage(to target:ImageConsumer, atIndex:UInt) {
-        imageFramebuffer.lock()
         target.newFramebufferAvailable(imageFramebuffer, fromSourceIndex:atIndex)
     }
     

--- a/framework/Source/Mac/Camera.swift
+++ b/framework/Source/Mac/Camera.swift
@@ -128,13 +128,13 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
 
             if (self.captureAsYUV) {
                 let luminanceFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:self.orientation, size:GLSize(width:GLint(bufferWidth), height:GLint(bufferHeight)), textureOnly:true)
-                luminanceFramebuffer.lock()
+                
                 glActiveTexture(GLenum(GL_TEXTURE0))
                 glBindTexture(GLenum(GL_TEXTURE_2D), luminanceFramebuffer.texture)
                 glTexImage2D(GLenum(GL_TEXTURE_2D), 0, GL_LUMINANCE, GLsizei(bufferWidth), GLsizei(bufferHeight), 0, GLenum(GL_LUMINANCE), GLenum(GL_UNSIGNED_BYTE), CVPixelBufferGetBaseAddressOfPlane(cameraFrame, 0))
 
                 let chrominanceFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:self.orientation, size:GLSize(width:GLint(bufferWidth), height:GLint(bufferHeight)), textureOnly:true)
-                chrominanceFramebuffer.lock()
+                
                 glActiveTexture(GLenum(GL_TEXTURE1))
                 glBindTexture(GLenum(GL_TEXTURE_2D), chrominanceFramebuffer.texture)
                 glTexImage2D(GLenum(GL_TEXTURE_2D), 0, GL_LUMINANCE_ALPHA, GLsizei(bufferWidth / 2), GLsizei(bufferHeight / 2), 0, GLenum(GL_LUMINANCE_ALPHA), GLenum(GL_UNSIGNED_BYTE), CVPixelBufferGetBaseAddressOfPlane(cameraFrame, 1))

--- a/framework/Source/Mac/MovieInput.swift
+++ b/framework/Source/Mac/MovieInput.swift
@@ -158,13 +158,13 @@ public class MovieInput: ImageSource {
         let startTime = CFAbsoluteTimeGetCurrent()
 
         let luminanceFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:.portrait, size:GLSize(width:GLint(bufferWidth), height:GLint(bufferHeight)), textureOnly:true)
-        luminanceFramebuffer.lock()
+        
         glActiveTexture(GLenum(GL_TEXTURE0))
         glBindTexture(GLenum(GL_TEXTURE_2D), luminanceFramebuffer.texture)
         glTexImage2D(GLenum(GL_TEXTURE_2D), 0, GL_LUMINANCE, GLsizei(bufferWidth), GLsizei(bufferHeight), 0, GLenum(GL_LUMINANCE), GLenum(GL_UNSIGNED_BYTE), CVPixelBufferGetBaseAddressOfPlane(movieFrame, 0))
         
         let chrominanceFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:.portrait, size:GLSize(width:GLint(bufferWidth), height:GLint(bufferHeight)), textureOnly:true)
-        chrominanceFramebuffer.lock()
+        
         glActiveTexture(GLenum(GL_TEXTURE1))
         glBindTexture(GLenum(GL_TEXTURE_2D), chrominanceFramebuffer.texture)
         glTexImage2D(GLenum(GL_TEXTURE_2D), 0, GL_LUMINANCE_ALPHA, GLsizei(bufferWidth / 2), GLsizei(bufferHeight / 2), 0, GLenum(GL_LUMINANCE_ALPHA), GLenum(GL_UNSIGNED_BYTE), CVPixelBufferGetBaseAddressOfPlane(movieFrame, 1))

--- a/framework/Source/Mac/MovieOutput.swift
+++ b/framework/Source/Mac/MovieOutput.swift
@@ -89,9 +89,6 @@ public class MovieOutput: ImageConsumer, AudioEncodingTarget {
     }
     
     public func newFramebufferAvailable(_ framebuffer:Framebuffer, fromSourceIndex:UInt) {
-        defer {
-            framebuffer.unlock()
-        }
         
         guard isRecording else { return }
         // Ignore still images and other non-video updates (do I still need this?)
@@ -132,7 +129,7 @@ public class MovieOutput: ImageConsumer, AudioEncodingTarget {
     
     func renderIntoPixelBuffer(_ pixelBuffer:CVPixelBuffer, framebuffer:Framebuffer) {
         let renderFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:framebuffer.orientation, size:GLSize(self.size))
-        renderFramebuffer.lock()
+        
         
         renderFramebuffer.activateFramebufferForRendering()
         clearFramebufferWithColor(Color.black)
@@ -141,7 +138,7 @@ public class MovieOutput: ImageConsumer, AudioEncodingTarget {
 
         CVPixelBufferLockBaseAddress(pixelBuffer, CVPixelBufferLockFlags(rawValue: CVOptionFlags(0)))
         glReadPixels(0, 0, renderFramebuffer.size.width, renderFramebuffer.size.height, GLenum(GL_BGRA), GLenum(GL_UNSIGNED_BYTE), CVPixelBufferGetBaseAddress(pixelBuffer))
-        renderFramebuffer.unlock()
+        
     }
     
     // MARK: -

--- a/framework/Source/Mac/PictureInput.swift
+++ b/framework/Source/Mac/PictureInput.swift
@@ -143,7 +143,7 @@ public class PictureInput: ImageSource {
     
     public func transmitPreviousImage(to target:ImageConsumer, atIndex:UInt) {
         if hasProcessedImage {
-            imageFramebuffer.lock()
+            
             target.newFramebufferAvailable(imageFramebuffer, fromSourceIndex:atIndex)
         }
     }

--- a/framework/Source/Mac/PictureOutput.swift
+++ b/framework/Source/Mac/PictureOutput.swift
@@ -41,7 +41,7 @@ public class PictureOutput: ImageConsumer {
     // TODO: Replace with texture caches and a safer capture routine
     func cgImageFromFramebuffer(_ framebuffer:Framebuffer) -> CGImage {
         let renderFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:framebuffer.orientation, size:framebuffer.size)
-        renderFramebuffer.lock()
+        
         renderFramebuffer.activateFramebufferForRendering()
         clearFramebufferWithColor(Color.transparent)
 
@@ -52,12 +52,12 @@ public class PictureOutput: ImageConsumer {
 
         disableBlending()
         
-        framebuffer.unlock()
+        
         
         let imageByteSize = Int(framebuffer.size.width * framebuffer.size.height * 4)
         let data = UnsafeMutablePointer<UInt8>.allocate(capacity:imageByteSize)
         glReadPixels(0, 0, framebuffer.size.width, framebuffer.size.height, GLenum(GL_RGBA), GLenum(GL_UNSIGNED_BYTE), data)
-        renderFramebuffer.unlock()
+        
         guard let dataProvider = CGDataProvider(dataInfo: nil, data: data, size: imageByteSize, releaseData: dataProviderReleaseCallback) else {fatalError("Could not create CGDataProvider")}
         let defaultRGBColorSpace = CGColorSpaceCreateDeviceRGB()
         

--- a/framework/Source/Mac/RenderView.swift
+++ b/framework/Source/Mac/RenderView.swift
@@ -29,6 +29,6 @@ public class RenderView:NSOpenGLView, ImageConsumer {
         renderQuadWithShader(self.displayShader, vertices:scaledVertices, inputTextures:[framebuffer.texturePropertiesForTargetOrientation(.portrait)])
         sharedImageProcessingContext.presentBufferForDisplay()
         
-        framebuffer.unlock()
+        
     }
 }

--- a/framework/Source/Operations/AverageColorExtractor.swift
+++ b/framework/Source/Operations/AverageColorExtractor.swift
@@ -31,7 +31,7 @@ public class AverageColorExtractor: BasicOperation {
         var data = [UInt8](repeating:0, count:Int(framebuffer.size.width * framebuffer.size.height * 4))
         glReadPixels(0, 0, framebuffer.size.width, framebuffer.size.height, GLenum(GL_RGBA), GLenum(GL_UNSIGNED_BYTE), &data)
         renderFramebuffer = framebuffer
-        framebuffer.resetRetainCount()
+        
 
         let totalNumberOfPixels = Int(framebuffer.size.width * framebuffer.size.height)
 
@@ -55,18 +55,18 @@ func averageColorBySequentialReduction(inputFramebuffer:Framebuffer, shader:Shad
     let numberOfReductionsInX = floor(log(Double(inputSize.width)) / log(4.0))
     let numberOfReductionsInY = floor(log(Double(inputSize.height)) / log(4.0))
     let reductionsToHitSideLimit = Int(floor(min(numberOfReductionsInX, numberOfReductionsInY)))
-    inputFramebuffer.lock()
+    
     var previousFramebuffer = inputFramebuffer
     for currentReduction in 0..<reductionsToHitSideLimit {
         let currentStageSize = Size(width:Float(floor(Double(inputSize.width) / pow(4.0, Double(currentReduction) + 1.0))), height:Float(floor(Double(inputSize.height) / pow(4.0, Double(currentReduction) + 1.0))))
         let currentFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:previousFramebuffer.orientation, size:GLSize(currentStageSize))
-        currentFramebuffer.lock()
+        
         uniformSettings["texelWidth"] = 0.25 / currentStageSize.width
         uniformSettings["texelHeight"] = 0.25 / currentStageSize.height
         
         currentFramebuffer.activateFramebufferForRendering()
         renderQuadWithShader(shader, uniformSettings:uniformSettings, vertexBufferObject:sharedImageProcessingContext.standardImageVBO, inputTextures:[previousFramebuffer.texturePropertiesForTargetOrientation(currentFramebuffer.orientation)])
-        previousFramebuffer.unlock()
+        
         previousFramebuffer = currentFramebuffer
     }
     

--- a/framework/Source/Operations/AverageLuminanceExtractor.swift
+++ b/framework/Source/Operations/AverageLuminanceExtractor.swift
@@ -35,7 +35,7 @@ public class AverageLuminanceExtractor: BasicOperation {
         var data = [UInt8](repeating:0, count:Int(framebuffer.size.width * framebuffer.size.height * 4))
         glReadPixels(0, 0, framebuffer.size.width, framebuffer.size.height, GLenum(GL_BGRA), GLenum(GL_UNSIGNED_BYTE), &data)
         renderFramebuffer = framebuffer
-        framebuffer.resetRetainCount()
+        
         
         let totalNumberOfPixels = Int(framebuffer.size.width * framebuffer.size.height)
         

--- a/framework/Source/Operations/ImageBuffer.swift
+++ b/framework/Source/Operations/ImageBuffer.swift
@@ -13,13 +13,13 @@ public class ImageBuffer: ImageProcessingOperation {
         if (bufferedFramebuffers.count > Int(bufferSize)) {
             let releasedFramebuffer = bufferedFramebuffers.removeFirst()
             updateTargetsWithFramebuffer(releasedFramebuffer)
-            releasedFramebuffer.unlock()
+            
         } else if activatePassthroughOnNextFrame {
             activatePassthroughOnNextFrame = false
             // Pass along the current frame to keep processing going until the buffer is built up
-            framebuffer.lock()
+            
             updateTargetsWithFramebuffer(framebuffer)
-            framebuffer.unlock()
+            
         }
     }
     

--- a/framework/Source/Operations/LanczosResampling.swift
+++ b/framework/Source/Operations/LanczosResampling.swift
@@ -9,7 +9,7 @@ public class LanczosResampling: BasicOperation {
         // Shrink the vertical component of the first stage
         let inputSize = inputFramebuffer.sizeForTargetOrientation(.portrait)
         let firstStageFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:.portrait, size:GLSize(width:inputSize.width, height:renderFramebuffer.size.height), stencil:false)
-        firstStageFramebuffer.lock()
+        
         firstStageFramebuffer.activateFramebufferForRendering()
         clearFramebufferWithColor(backgroundColor)
         
@@ -27,6 +27,6 @@ public class LanczosResampling: BasicOperation {
         
         renderFramebuffer.activateFramebufferForRendering()
         renderQuadWithShader(shader, uniformSettings:uniformSettings, vertexBufferObject:sharedImageProcessingContext.standardImageVBO, inputTextures:[firstStageFramebuffer.texturePropertiesForOutputRotation(.noRotation)])
-        firstStageFramebuffer.unlock()
+        
     }
 }

--- a/framework/Source/Pipeline.swift
+++ b/framework/Source/Pipeline.swift
@@ -52,15 +52,6 @@ public extension ImageSource {
     }
     
     public func updateTargetsWithFramebuffer(_ framebuffer:Framebuffer) {
-        if targets.count == 0 { // Deal with the case where no targets are attached by immediately returning framebuffer to cache
-            framebuffer.lock()
-            framebuffer.unlock()
-        } else {
-            // Lock first for each output, to guarantee proper ordering on multi-output operations
-            for _ in targets {
-                framebuffer.lock()
-            }
-        }
         for (target, index) in targets {
             target.newFramebufferAvailable(framebuffer, fromSourceIndex:index)
         }
@@ -215,11 +206,6 @@ public class ImageRelay: ImageProcessingOperation {
     }
     
     public func relayFramebufferOnward(_ framebuffer:Framebuffer) {
-        // Need to override to guarantee a removal of the previously applied lock
-        for _ in targets {
-            framebuffer.lock()
-        }
-        framebuffer.unlock()
         for (target, index) in targets {
             target.newFramebufferAvailable(framebuffer, fromSourceIndex:index)
         }

--- a/framework/Source/RawDataOutput.swift
+++ b/framework/Source/RawDataOutput.swift
@@ -24,16 +24,16 @@ public class RawDataOutput: ImageConsumer {
     // TODO: Replace with texture caches
     public func newFramebufferAvailable(_ framebuffer:Framebuffer, fromSourceIndex:UInt) {
         let renderFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:framebuffer.orientation, size:framebuffer.size)
-        renderFramebuffer.lock()
+        
 
         renderFramebuffer.activateFramebufferForRendering()
         clearFramebufferWithColor(Color.black)
         renderQuadWithShader(sharedImageProcessingContext.passthroughShader, uniformSettings:ShaderUniformSettings(), vertexBufferObject:sharedImageProcessingContext.standardImageVBO, inputTextures:[framebuffer.texturePropertiesForOutputRotation(.noRotation)])
-        framebuffer.unlock()
+        
         
         var data = [UInt8](repeating:0, count:Int(framebuffer.size.width * framebuffer.size.height * 4))
         glReadPixels(0, 0, framebuffer.size.width, framebuffer.size.height, GLenum(GL_RGBA), GLenum(GL_UNSIGNED_BYTE), &data)
-        renderFramebuffer.unlock()
+        
 
         dataAvailableCallback?(data)
     }

--- a/framework/Source/TextureInput.swift
+++ b/framework/Source/TextureInput.swift
@@ -30,7 +30,6 @@ public class TextureInput: ImageSource {
     }
     
     public func transmitPreviousImage(to target:ImageConsumer, atIndex:UInt) {
-        textureFramebuffer.lock()
         target.newFramebufferAvailable(textureFramebuffer, fromSourceIndex:atIndex)
     }
 }

--- a/framework/Source/TextureOutput.swift
+++ b/framework/Source/TextureOutput.swift
@@ -21,6 +21,6 @@ public class TextureOutput: ImageConsumer {
     public func newFramebufferAvailable(_ framebuffer:Framebuffer, fromSourceIndex:UInt) {
         newTextureAvailableCallback?(framebuffer.texture)
         // TODO: Maybe extend the lifetime of the texture past this if needed
-        framebuffer.unlock()
+        
     }
 }

--- a/framework/Source/iOS/Camera.swift
+++ b/framework/Source/iOS/Camera.swift
@@ -210,14 +210,14 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
                 } else {
                     glActiveTexture(GLenum(GL_TEXTURE4))
                     luminanceFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:self.location.imageOrientation(), size:GLSize(width:GLint(bufferWidth), height:GLint(bufferHeight)), textureOnly:true)
-                    luminanceFramebuffer.lock()
+                    
                     
                     glBindTexture(GLenum(GL_TEXTURE_2D), luminanceFramebuffer.texture)
                     glTexImage2D(GLenum(GL_TEXTURE_2D), 0, GL_LUMINANCE, GLsizei(bufferWidth), GLsizei(bufferHeight), 0, GLenum(GL_LUMINANCE), GLenum(GL_UNSIGNED_BYTE), CVPixelBufferGetBaseAddressOfPlane(cameraFrame, 0))
                     
                     glActiveTexture(GLenum(GL_TEXTURE5))
                     chrominanceFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:self.location.imageOrientation(), size:GLSize(width:GLint(bufferWidth / 2), height:GLint(bufferHeight / 2)), textureOnly:true)
-                    chrominanceFramebuffer.lock()
+                    
                     glBindTexture(GLenum(GL_TEXTURE_2D), chrominanceFramebuffer.texture)
                     glTexImage2D(GLenum(GL_TEXTURE_2D), 0, GL_LUMINANCE_ALPHA, GLsizei(bufferWidth / 2), GLsizei(bufferHeight / 2), 0, GLenum(GL_LUMINANCE_ALPHA), GLenum(GL_UNSIGNED_BYTE), CVPixelBufferGetBaseAddressOfPlane(cameraFrame, 1))
                 }

--- a/framework/Source/iOS/MovieInput.swift
+++ b/framework/Source/iOS/MovieInput.swift
@@ -158,13 +158,13 @@ public class MovieInput: ImageSource {
         let startTime = CFAbsoluteTimeGetCurrent()
 
         let luminanceFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:.portrait, size:GLSize(width:GLint(bufferWidth), height:GLint(bufferHeight)), textureOnly:true)
-        luminanceFramebuffer.lock()
+        
         glActiveTexture(GLenum(GL_TEXTURE0))
         glBindTexture(GLenum(GL_TEXTURE_2D), luminanceFramebuffer.texture)
         glTexImage2D(GLenum(GL_TEXTURE_2D), 0, GL_LUMINANCE, GLsizei(bufferWidth), GLsizei(bufferHeight), 0, GLenum(GL_LUMINANCE), GLenum(GL_UNSIGNED_BYTE), CVPixelBufferGetBaseAddressOfPlane(movieFrame, 0))
         
         let chrominanceFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:.portrait, size:GLSize(width:GLint(bufferWidth), height:GLint(bufferHeight)), textureOnly:true)
-        chrominanceFramebuffer.lock()
+        
         glActiveTexture(GLenum(GL_TEXTURE1))
         glBindTexture(GLenum(GL_TEXTURE_2D), chrominanceFramebuffer.texture)
         glTexImage2D(GLenum(GL_TEXTURE_2D), 0, GL_LUMINANCE_ALPHA, GLsizei(bufferWidth / 2), GLsizei(bufferHeight / 2), 0, GLenum(GL_LUMINANCE_ALPHA), GLenum(GL_UNSIGNED_BYTE), CVPixelBufferGetBaseAddressOfPlane(movieFrame, 1))

--- a/framework/Source/iOS/MovieOutput.swift
+++ b/framework/Source/iOS/MovieOutput.swift
@@ -117,9 +117,7 @@ public class MovieOutput: ImageConsumer, AudioEncodingTarget {
     }
     
     public func newFramebufferAvailable(_ framebuffer:Framebuffer, fromSourceIndex:UInt) {
-        defer {
-            framebuffer.unlock()
-        }
+        
         guard isRecording else { return }
         // Ignore still images and other non-video updates (do I still need this?)
         guard let frameTime = framebuffer.timingStyle.timestamp?.asCMTime else { return }
@@ -161,7 +159,7 @@ public class MovieOutput: ImageConsumer, AudioEncodingTarget {
     func renderIntoPixelBuffer(_ pixelBuffer:CVPixelBuffer, framebuffer:Framebuffer) {
         if !sharedImageProcessingContext.supportsTextureCaches() {
             renderFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:framebuffer.orientation, size:GLSize(self.size))
-            renderFramebuffer.lock()
+            
         }
         
         renderFramebuffer.activateFramebufferForRendering()
@@ -173,7 +171,7 @@ public class MovieOutput: ImageConsumer, AudioEncodingTarget {
             glFinish()
         } else {
             glReadPixels(0, 0, renderFramebuffer.size.width, renderFramebuffer.size.height, GLenum(GL_RGBA), GLenum(GL_UNSIGNED_BYTE), CVPixelBufferGetBaseAddress(pixelBuffer))
-            renderFramebuffer.unlock()
+            
         }
     }
     

--- a/framework/Source/iOS/PictureInput.swift
+++ b/framework/Source/iOS/PictureInput.swift
@@ -141,7 +141,7 @@ public class PictureInput: ImageSource {
     
     public func transmitPreviousImage(to target:ImageConsumer, atIndex:UInt) {
         if hasProcessedImage {
-            imageFramebuffer.lock()
+            
             target.newFramebufferAvailable(imageFramebuffer, fromSourceIndex:atIndex)
         }
     }

--- a/framework/Source/iOS/PictureOutput.swift
+++ b/framework/Source/iOS/PictureOutput.swift
@@ -41,16 +41,16 @@ public class PictureOutput: ImageConsumer {
     // TODO: Replace with texture caches
     func cgImageFromFramebuffer(_ framebuffer:Framebuffer) -> CGImage {
         let renderFramebuffer = sharedImageProcessingContext.framebufferCache.requestFramebufferWithProperties(orientation:framebuffer.orientation, size:framebuffer.size)
-        renderFramebuffer.lock()
+        
         renderFramebuffer.activateFramebufferForRendering()
         clearFramebufferWithColor(Color.red)
         renderQuadWithShader(sharedImageProcessingContext.passthroughShader, uniformSettings:ShaderUniformSettings(), vertexBufferObject:sharedImageProcessingContext.standardImageVBO, inputTextures:[framebuffer.texturePropertiesForOutputRotation(.noRotation)])
-        framebuffer.unlock()
+        
         
         let imageByteSize = Int(framebuffer.size.width * framebuffer.size.height * 4)
         let data = UnsafeMutablePointer<UInt8>.allocate(capacity: imageByteSize)
         glReadPixels(0, 0, framebuffer.size.width, framebuffer.size.height, GLenum(GL_RGBA), GLenum(GL_UNSIGNED_BYTE), data)
-        renderFramebuffer.unlock()
+        
         guard let dataProvider = CGDataProvider(dataInfo:nil, data:data, size:imageByteSize, releaseData: dataProviderReleaseCallback) else {fatalError("Could not allocate a CGDataProvider")}
         let defaultRGBColorSpace = CGColorSpaceCreateDeviceRGB()
         return CGImage(width:Int(framebuffer.size.width), height:Int(framebuffer.size.height), bitsPerComponent:8, bitsPerPixel:32, bytesPerRow:4 * Int(framebuffer.size.width), space:defaultRGBColorSpace, bitmapInfo:CGBitmapInfo() /*| CGImageAlphaInfo.Last*/, provider:dataProvider, decode:nil, shouldInterpolate:false, intent:.defaultIntent)!
@@ -58,7 +58,6 @@ public class PictureOutput: ImageConsumer {
     
     public func newFramebufferAvailable(_ framebuffer:Framebuffer, fromSourceIndex:UInt) {
         if keepImageAroundForSynchronousCapture {
-            storedFramebuffer?.unlock()
             storedFramebuffer = framebuffer
         }
         

--- a/framework/Source/iOS/RenderView.swift
+++ b/framework/Source/iOS/RenderView.swift
@@ -110,7 +110,7 @@ public class RenderView:UIView, ImageConsumer {
 
         let scaledVertices = fillMode.transformVertices(verticallyInvertedImageVertices, fromInputSize:framebuffer.sizeForTargetOrientation(self.orientation), toFitSize:backingSize)
         renderQuadWithShader(self.displayShader, vertices:scaledVertices, inputTextures:[framebuffer.texturePropertiesForTargetOrientation(self.orientation)])
-        framebuffer.unlock()
+        
         
         glBindRenderbuffer(GLenum(GL_RENDERBUFFER), displayRenderbuffer!)
         sharedImageProcessingContext.presentBufferForDisplay()


### PR DESCRIPTION
I modified `Framebuffer` to support caching mechanism under ARC(Automatic Reference Counting) by using **hidden core framebuffer class** (`Framebuffer.Core` in Framebuffer.swift).

The way this works is that `FramebufferCache` caches only the `Framebuffer.Core` object and returns the wrapped `Framebuffer` object. 

`Framebuffer` object has **`deinit()`** methods that returns the internal `Framebuffer.Core` object to cache if it exists. This way the framebuffer is safely returned to the cache when it is not referenced without worrying about locking/unlocking.

`Framebuffer` class redirects all the methods and variable properties to the internal `Framebuffer.Core` object and has same constant properties with it.

`lock()`, `unlock()`, `resetRetainCount()`, `framebufferRetainCount` are removed accordingly.