### PR TITLE
Exposed CameraError to allow calling function to more gracefully hand…

### DIFF
--- a/framework/Source/iOS/Camera.swift
+++ b/framework/Source/iOS/Camera.swift
@@ -35,7 +35,7 @@ public enum PhysicalCameraLocation {
     }
 }
 
-struct CameraError: Error {
+public struct CameraError: Error {
 }
 
 let initialBenchmarkFramesToIgnore = 5
@@ -161,7 +161,7 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
     deinit {
         sharedImageProcessingContext.runOperationSynchronously{
             self.stopCapture()
-            self.videoOutput.setSampleBufferDelegate(nil, queue:nil)
+            self.videoOutput?.setSampleBufferDelegate(nil, queue:nil)
             self.audioOutput?.setSampleBufferDelegate(nil, queue:nil)
         }
     }


### PR DESCRIPTION
I find that when running on a device without a front facing camera (e.g. the simulator), i get a program crash during the deinit when the Camera() init fails.

2 Simple changes: 

1) expose the CameraError so that other classes can catch it.
2) mark the videoOutput as optional so that it won't crash if it doesn't exist while unwrapping during deinit.

Please note I'm quite new to git so not sure if I'm doing the right thing regarding pull requests etc.