### PR TITLE
Make the image generator open

### DIFF
--- a/framework/Source/ImageGenerator.swift
+++ b/framework/Source/ImageGenerator.swift
@@ -1,4 +1,4 @@
-public class ImageGenerator: ImageSource {
+open class ImageGenerator: ImageSource {
     public var size:Size
 
     public let targets = TargetContainer()


### PR DESCRIPTION
Hi,

I was trying to make a custom image generator to make rectangle generator like circle generator in the GPUImage2 module. 

I needed image generator to be open in order to inherit outside of the GPUImage2 module.

open class ImageGenerator:

This PR changes the ImageGenerator to open to make that possible.