### PR TITLE
change AVMediaTypeVideo to AVMediaType.video

### DIFF
--- a/framework/Source/iOS/Camera.swift
+++ b/framework/Source/iOS/Camera.swift
@@ -154,7 +154,7 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
         var captureConnection: AVCaptureConnection!
         for connection in videoOutput.connections {
             for port in (connection as! AVCaptureConnection).inputPorts {
-                if (port as AnyObject).mediaType == AVMediaTypeVideo {
+                if (port as AnyObject).mediaType == AVMediaType.video {
                     captureConnection = connection as? AVCaptureConnection
                     captureConnection.isVideoMirrored = location == .frontFacing
                 }


### PR DESCRIPTION
Hi, Brad.
I found out that there is some minor error in the latest commit 33db0e9435e75cc31cd684aaadd6098ed2297fb1
In camera class, there is AVMediaTypeVideo which renamed AVMediaType.video.
In some environment, there is build error. 
Could you fix ASAP?
Thanks. 
