### PR TITLE
make framebuffer lock public

### DIFF
--- a/framework/Source/Framebuffer.swift
+++ b/framework/Source/Framebuffer.swift
@@ -162,7 +162,7 @@ public class Framebuffer {
 
     weak var cache:FramebufferCache?
     var framebufferRetainCount = 0
-    func lock() {
+    public func lock() {
         framebufferRetainCount += 1
     }
 


### PR DESCRIPTION
Hi, Brad!
I'm so inspired by your work ever since I started a project with your GPUImage2.
I make this pull request to make lock in frame buffer class public.
I'm trying to make customized image generator. 
`func transmitPreviousImage(to target:ImageConsumer, atIndex:UInt) {
imageFramebuffer.lock()
target.newFramebufferAvailable(imageFramebuffer, fromSourceIndex:atIndex)
}
`
And I want to build transmitPreviousImage function like above. 
Unfortunately, lock function is not public. 
I will wait for your comment. 
Thanks.