### PR TITLE
Fix framebuffer over release issue

### DIFF
--- a/framework/Source/Pipeline.swift
+++ b/framework/Source/Pipeline.swift
@@ -52,16 +52,21 @@ public extension ImageSource {
     }
     
     public func updateTargetsWithFramebuffer(_ framebuffer:Framebuffer) {
-        if targets.count == 0 { // Deal with the case where no targets are attached by immediately returning framebuffer to cache
+        var foundTargets = [(ImageConsumer, UInt)]()
+        for target in targets {
+            foundTargets.append(target)
+        }
+        
+        if foundTargets.count == 0 { // Deal with the case where no targets are attached by immediately returning framebuffer to cache
             framebuffer.lock()
             framebuffer.unlock()
         } else {
             // Lock first for each output, to guarantee proper ordering on multi-output operations
-            for _ in targets {
+            for _ in foundTargets {
                 framebuffer.lock()
             }
         }
-        for (target, index) in targets {
+        for (target, index) in foundTargets {
             target.newFramebufferAvailable(framebuffer, fromSourceIndex:index)
         }
     }


### PR DESCRIPTION
Hi, I'm developing an app with this amazing open library GPUImage2. Thanks to Bard. 
But sometimes my app crashes due to framebuffer overrelease issue. 
My app changes pipeline a lot. And this issue appears when pipeline is changed.
I tried to figure out this error and I found out that there is solution for this issue. 
This PullRequest #243 explains what are the problems and solutions kindly. @joshbernfeld
But this pull request didn't merged because of unknown error, I guess. 
So I make a pull request with core solution in #243. 
And  I test this code with my own app and it solves a problem. 
I will wait for your comment.
Thanks.
