### PR TITLE
Synchronously lookup shader from cache

### DIFF
--- a/framework/Source/OpenGLContext_Shared.swift
+++ b/framework/Source/OpenGLContext_Shared.swift
@@ -22,7 +22,7 @@ public let sharedImageProcessingContext = OpenGLContext()
 extension OpenGLContext {
     public func programForVertexShader(_ vertexShader:String, fragmentShader:String) throws -> ShaderProgram {
         let lookupKeyForShaderProgram = "V: \(vertexShader) - F: \(fragmentShader)"
-        if let shaderFromCache = shaderCache[lookupKeyForShaderProgram] {
+        if let shaderFromCache = sharedImageProcessingContext.runOperationSynchronously({ shaderCache[lookupKeyForShaderProgram] }) {
             return shaderFromCache
         } else {
             return try sharedImageProcessingContext.runOperationSynchronously{


### PR DESCRIPTION
This is to avoid crash when `shaderCache` is mutating and lookup happens